### PR TITLE
only create labels on issue creation

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,9 +1,15 @@
-on: issues
 name: Create Default Labels
+
+on:
+  issues:
+    type: [ opened ]
+
 jobs:
   labels:
-    name: DefaultLabelsActions
+    name: Create Default Labels
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@1.0.0
       - uses: lannonbr/issue-label-manager-action@2.0.0


### PR DESCRIPTION
otherwise it runs on every edit, closing, opening, label added, etc.